### PR TITLE
Fix a problem of deltaX and deltaY

### DIFF
--- a/js/scrollback.js
+++ b/js/scrollback.js
@@ -1,6 +1,6 @@
 document.addEventListener("wheel", function(e) {
-  if (e.shiftKey && e.deltaX != 0) {
-    window.history.go(-Math.sign(e.deltaX));
+  if (e.shiftKey && (e.deltaX != 0 || e.deltaY != 0)) {
+    window.history.go(-Math.sign(e.deltaX ? e.deltaX : e.deltaY));
     return e.preventDefault();
   }
 });


### PR DESCRIPTION
There is a change in the recent version of chrome, which disables this add-on.
It seems like new chrome version thinks mouse scroll is not deltaX anymore.
This PR solves this issue. It will react on both horizontal and vertical scrolls.

@jezcope Please merge this and update the add-on on the chrome webstore that many people are waiting for.

Signed-off-by: Dongyun Jin <mylibero@gmail.com>